### PR TITLE
Updating headings for a11y

### DIFF
--- a/css/pmpro-goals.css
+++ b/css/pmpro-goals.css
@@ -48,8 +48,8 @@
 .wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-enddate .components-datetime__date .css-1syzhqb:nth-of-type(7) {
   justify-self: center;
 }
-.wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-startdate .components-datetime__date h3,
-.wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-enddate .components-datetime__date h3 {
+.wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-startdate .components-datetime__date h2,
+.wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-enddate .components-datetime__date h2 {
   margin: 0;
 }
 .wp-block-pmpro-goals-goal-progress .datepicker-component-wrapper .datepicker-component-startdate .components-datetime__buttons,

--- a/scss/pmpro-goals.scss
+++ b/scss/pmpro-goals.scss
@@ -59,7 +59,7 @@ $bp-xs: 768px;
         .css-1syzhqb:nth-of-type(7) {
           justify-self: center;
         }
-        h3 {
+        h2 {
           margin: 0;
         }
       }


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates the headings from h3 to h2. 